### PR TITLE
Allow BAY_TYPES to be automatically filled.

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -147,10 +147,7 @@ const vector<string> Ship::CATEGORIES = {
 
 
 // Set of ship types that can be carried in bays.
-const set<string> Ship::BAY_TYPES = {
-	"Drone",
-	"Fighter"
-};
+set<string> Ship::BAY_TYPES = {};
 
 
 
@@ -319,12 +316,13 @@ void Ship::Load(const DataNode &node)
 				category = child.Token(1);
 				childOffset += 1;
 			}
-			if(!BAY_TYPES.count(category))
+			if(find(CATEGORIES.begin(), CATEGORIES.end(), category) == CATEGORIES.end())
 			{
 				child.PrintTrace("Warning: Invalid category defined for bay:");
 				continue;
 			}
-			
+			// BAY_TYPES is a set, so no need to check if the type was already present.
+			BAY_TYPES.insert(category);
 			if(!hasBays)
 			{
 				bays.clear();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -56,8 +56,9 @@ class Ship : public Body, public std::enable_shared_from_this<Ship> {
 public:
 	// These are all the possible category strings for ships.
 	static const std::vector<std::string> CATEGORIES;
-	// Allow retrieving the available bay types for the current game;
-	static const std::set<std::string> BAY_TYPES;
+	// Allow retrieving the available bay types for the current game.
+	// Non-const, generated from the bays we encounter.
+	static std::set<std::string> BAY_TYPES;
 	
 	class Bay {
 	public:


### PR DESCRIPTION
Replace check against BAY_TYPES by a check on valid categories.

NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!) 

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
{{summarize your content! Include links to related issues, in-game screenshots, etc.}}

## Save File
This save file can be used to play through the new mission content:
{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}

## PR Checklist
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
  
  
-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
{{add details}}

## Testing Done
{{describe how you tested that the fix doesn't introduce other issues}}

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}


-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
{{add details about the feature you implemented}}

## UI Screenshots
{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}

## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
{{describe how you tested the new feature}}

## Performance Impact
{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}
