### PR TITLE
Parallax stars/haze, along with keybinds for testing specific ratios

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -215,9 +215,13 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		Messages::Add("Your escorts will now expend ammo: " + Preferences::AmmoUsage() + ".");
 	}
 	else if((key == SDLK_MINUS || key == SDLK_KP_MINUS) && !command)
-		Preferences::ZoomViewOut();
+		Preferences::StarZoomViewOut();
 	else if((key == SDLK_PLUS || key == SDLK_KP_PLUS || key == SDLK_EQUALS) && !command)
-		Preferences::ZoomViewIn();
+		Preferences::StarZoomViewIn();
+	else if((key == SDLK_PAGEUP) && !command)
+		Preferences::HazeZoomViewOut();
+	else if((key == SDLK_PAGEDOWN) && !command)
+		Preferences::HazeZoomViewIn();
 	else if(key >= '0' && key <= '9' && !command)
 		engine.SelectGroup(key - '0', mod & KMOD_SHIFT, mod & (KMOD_CTRL | KMOD_GUI));
 	else

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -22,6 +22,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <algorithm>
 #include <map>
+#include <iostream>
 
 using namespace std;
 
@@ -35,6 +36,10 @@ namespace {
 	
 	const vector<double> ZOOMS = {.25, .35, .50, .70, 1.00, 1.40, 2.00};
 	int zoomIndex = 4;
+	const vector<double> STARZOOMS = {.25, .35, .50, .60, .70, .80, .90, 1.00, 1.10, 1.25, 1.40, 2.00};
+	int starZoomIndex = 4;
+	const vector<double> HAZEZOOMS = {.25, .35, .50, .60, .70, .80, .90, 1.00, 1.10, 1.25, 1.40, 2.00};
+	int hazeZoomIndex = 6;
 	constexpr double VOLUME_SCALE = .25;
 	
 	// Enable standard VSync by default.
@@ -60,6 +65,7 @@ void Preferences::Load()
 	settings["Show hyperspace flash"] = true;
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
+	settings["Parallax space"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;
@@ -176,6 +182,70 @@ bool Preferences::ZoomViewOut()
 		return false;
 	
 	--zoomIndex;
+	return true;
+}
+
+
+
+// TEMP Star View zoom.
+double Preferences::StarViewZoom()
+{
+	return STARZOOMS[starZoomIndex];
+}
+
+
+
+bool Preferences::StarZoomViewIn()
+{
+	if(starZoomIndex == static_cast<int>(STARZOOMS.size() - 1))
+		return false;
+	
+	++starZoomIndex;
+	cout << "Star zoom is: " << STARZOOMS[starZoomIndex] << endl;
+	return true;
+}
+
+
+
+bool Preferences::StarZoomViewOut()
+{
+	if(starZoomIndex == 0)
+		return false;
+	
+	--starZoomIndex;
+	cout << "Star zoom is: " << STARZOOMS[starZoomIndex] << endl;
+	return true;
+}
+
+
+
+// TEMP Haze View zoom.
+double Preferences::HazeViewZoom()
+{
+	return HAZEZOOMS[hazeZoomIndex];
+}
+
+
+
+bool Preferences::HazeZoomViewIn()
+{
+	if(hazeZoomIndex == static_cast<int>(HAZEZOOMS.size() - 1))
+		return false;
+	
+	++hazeZoomIndex;
+	cout << "Haze zoom is: " << HAZEZOOMS[hazeZoomIndex] << endl;
+	return true;
+}
+
+
+
+bool Preferences::HazeZoomViewOut()
+{
+	if(hazeZoomIndex == 0)
+		return false;
+	
+	--hazeZoomIndex;
+	cout << "Haze zoom is: " << HAZEZOOMS[hazeZoomIndex] << endl;
 	return true;
 }
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -46,6 +46,12 @@ public:
 	static double ViewZoom();
 	static bool ZoomViewIn();
 	static bool ZoomViewOut();
+	static double StarViewZoom();
+	static bool StarZoomViewIn();
+	static bool StarZoomViewOut();
+	static double HazeViewZoom();
+	static bool HazeZoomViewIn();
+	static bool HazeZoomViewOut();
 	
 	// VSync setting, either "on", "off", or "adaptive".
 	static bool ToggleVSync();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -48,6 +48,8 @@ namespace {
 	const int ZOOM_FACTOR_MAX = 200;
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";
+	const string STAR_ZOOM_FACTOR = "TMP Star zoom factor";
+	const string HAZE_ZOOM_FACTOR = "TMP Haze factor";
 	const string VSYNC_SETTING = "VSync";
 	const string EXPEND_AMMO = "Escorts expend ammo";
 	const string TURRET_TRACKING = "Turret tracking";
@@ -171,6 +173,20 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 				// case, cycle around to the lowest zoom factor.
 				if(!Preferences::ZoomViewIn())
 					while(Preferences::ZoomViewOut()) {}
+			}
+			else if(zone.Value() == STAR_ZOOM_FACTOR)
+			{
+				// Increase the zoom factor unless it is at the maximum. In that
+				// case, cycle around to the lowest zoom factor.
+				if(!Preferences::StarZoomViewIn())
+					while(Preferences::StarZoomViewOut()) {}
+			}
+			else if(zone.Value() == HAZE_ZOOM_FACTOR)
+			{
+				// Increase the zoom factor unless it is at the maximum. In that
+				// case, cycle around to the lowest zoom factor.
+				if(!Preferences::HazeZoomViewIn())
+					while(Preferences::HazeZoomViewOut()) {}
 			}
 			else if(zone.Value() == VSYNC_SETTING)
 			{
@@ -432,6 +448,8 @@ void PreferencesPanel::DrawSettings()
 		"Display",
 		ZOOM_FACTOR,
 		VIEW_ZOOM_FACTOR,
+		STAR_ZOOM_FACTOR,
+		HAZE_ZOOM_FACTOR,
 		VSYNC_SETTING,
 		"Show status overlays",
 		"Highlight player's flagship",
@@ -452,6 +470,7 @@ void PreferencesPanel::DrawSettings()
 		"Reduce large graphics",
 		"Draw background haze",
 		"Draw starfield",
+		"Parallax space",
 		"Show hyperspace flash",
 		SHIP_OUTLINES,
 		"",
@@ -505,6 +524,16 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = true;
 			text = to_string(static_cast<int>(100. * Preferences::ViewZoom()));
+		}
+		else if(setting == STAR_ZOOM_FACTOR)
+		{
+			isOn = true;
+			text = to_string(static_cast<int>(100. * Preferences::StarViewZoom()));
+		}
+		else if(setting == HAZE_ZOOM_FACTOR)
+		{
+			isOn = true;
+			text = to_string(static_cast<int>(100. * Preferences::HazeViewZoom()));
 		}
 		else if(setting == VSYNC_SETTING)
 		{

--- a/source/StarField.cpp
+++ b/source/StarField.cpp
@@ -90,9 +90,14 @@ void StarField::SetHaze(const Sprite *sprite)
 
 void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 {
+	double savedZoom = zoom;
+
 	// Draw the starfield unless it is disabled in the preferences.
 	if(Preferences::Has("Draw starfield"))
 	{
+		// Modify zoom for first parallax layer
+		if(Preferences::Has("Parallax space"))
+			zoom = savedZoom * Preferences::StarViewZoom();	
 		glUseProgram(shader.Object());
 		glBindVertexArray(vao);
 	
@@ -150,9 +155,16 @@ void StarField::Draw(const Point &pos, const Point &vel, double zoom) const
 	if(!Preferences::Has("Draw background haze"))
 		return;
 	
+	// Modify zoom for second parallax layer
+	if(Preferences::Has("Parallax space"))
+		zoom = savedZoom * Preferences::HazeViewZoom();
+	
 	DrawList drawList;
 	drawList.Clear(0, zoom);
 	drawList.SetCenter(pos);
+	
+	// Set zoom to max for haze, so they won't get culled prematurely
+	zoom = .25;
 	
 	// Any object within this range must be drawn. Some haze sprites may repeat
 	// more than once if the view covers a very large area.


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!) 

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
{{summarize your content! Include links to related issues, in-game screenshots, etc.}}

## Save File
This save file can be used to play through the new mission content:
{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}

## PR Checklist
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I uploaded the necessary image, blend, and texture assets here: {{insert link to assets}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
  
  
-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
{{add details}}

## Testing Done
{{describe how you tested that the fix doesn't introduce other issues}}

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}


-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
{{add details about the feature you implemented}}

## UI Screenshots
{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}

## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
{{describe how you tested the new feature}}

## Performance Impact
{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}
