### PR TITLE
Patch 6

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -633,8 +633,10 @@ void Engine::Step(bool isActive)
 		info.SetString("location", currentSystem->Name());
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
-	{ //if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
-		if ( flagship->Attributes().Get("fuel capacity") <= 1200)
+	{
+		const double fuelCap = 2000.;
+		// if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
+		if ( flagship->Attributes().Get("fuel capacity") <= fuelCap)
 		{
 			info.SetBar("fuel", flagship->Fuel(),
 				flagship->Attributes().Get("fuel capacity") * .01);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -635,11 +635,12 @@ void Engine::Step(bool isActive)
 	if(flagship)
 	{
 		const double fuelCap = 2000.;
-		// if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
-		if ( flagship->Attributes().Get("fuel capacity") <= fuelCap)
+		// If there is a lot of fuel, display a solid homogenous bar,
+		// instead of many notches in the bar.
+		if(flagship->Attributes().Get("fuel capacity") <= fuelCap)
 		{
 			info.SetBar("fuel", flagship->Fuel(),
-				flagship->Attributes().Get("fuel capacity") * .01);
+				    flagship->Attributes().Get("fuel capacity") * .01);
 		} else {
 			info.SetBar("fuel", flagship->Fuel());
 		}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -633,9 +633,14 @@ void Engine::Step(bool isActive)
 		info.SetString("location", currentSystem->Name());
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
-	{
-		info.SetBar("fuel", flagship->Fuel(),
-			flagship->Attributes().Get("fuel capacity") * .01);
+	{ //if there is a lot of fuel, display a solid homogenous bar instead of many notches in the bar
+		if ( flagship->Attributes().Get("fuel capacity") <= 1200)
+		{
+			info.SetBar("fuel", flagship->Fuel(),
+				flagship->Attributes().Get("fuel capacity") * .01);
+		} else {
+			info.SetBar("fuel", flagship->Fuel());
+		}
 		info.SetBar("energy", flagship->Energy());
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -634,16 +634,14 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		const double fuelCap = 2000.;
+		const double MAX_FUEL_DISPLAY = 5000.;
+		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.
-		if(flagship->Attributes().Get("fuel capacity") <= fuelCap)
-		{
-			info.SetBar("fuel", flagship->Fuel(),
-				    flagship->Attributes().Get("fuel capacity") * .01);
-		} else {
+		if(fuelCap <= MAX_FUEL_DISPLAY )
+			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
+		else
 			info.SetBar("fuel", flagship->Fuel());
-		}
 		info.SetBar("energy", flagship->Energy());
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -638,7 +638,7 @@ void Engine::Step(bool isActive)
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.
-		if(fuelCap <= MAX_FUEL_DISPLAY )
+		if(fuelCap <= MAX_FUEL_DISPLAY)
 			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -187,6 +187,7 @@ namespace {
 	}
 	
 	const double RADAR_SCALE = .025;
+	const double MAX_FUEL_DISPLAY = 5000.;
 }
 
 
@@ -634,7 +635,6 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		const double MAX_FUEL_DISPLAY = 5000.;
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If there is a lot of fuel, display a solid homogenous bar,
 		// instead of many notches in the bar.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -636,10 +636,10 @@ void Engine::Step(bool isActive)
 	if(flagship)
 	{
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
-		// If there is a lot of fuel, display a solid homogenous bar,
-		// instead of many notches in the bar.
+		// If the flagship has a large amount of fuel, display a solid bar.
+		// Otherwise, display a segment for every 100 fuel.
 		if(fuelCap <= MAX_FUEL_DISPLAY)
-			info.SetBar("fuel", flagship->Fuel(), fuelCap* .01);
+			info.SetBar("fuel", flagship->Fuel(), fuelCap * .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());
 		info.SetBar("energy", flagship->Energy());


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
{{summarize your content! Include links to related issues, in-game screenshots, etc.}}

## Save File
This save file can be used to play through the new mission content:
{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}

## Artwork Checklist
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/EndlessSkyCommunity/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}


-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
{{add details}}

## Testing Done
{{describe how you tested that the fix doesn't introduce other issues}}

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}


-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
{{add details about the feature you implemented}}

## UI Screenshots
{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}

## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
{{describe how you tested the new feature}}

## Performance Impact
{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}
