### PR TITLE
Defensive cloaking

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2890,7 +2890,8 @@ bool AI::DoCloak(Ship &ship, Command &command)
 			}
 		}
 		// Choose to cloak if there are no enemies nearby and cloaking is sensible.
-		if(range == MAX_RANGE && cloakFreely && !ship.GetTargetShip())
+		// Player ships should never cloak automatically if not damaged.
+		if(range == MAX_RANGE && cloakFreely && !ship.GetTargetShip() && !ship.IsYours())
 			command |= Command::CLOAK;
 	}
 	return false;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -627,13 +627,16 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 			if(isCloaking)
 				command |= Command::CLOAK;
 		}
+
 		// Cloak if the AI considers it appropriate.
-		if((!it->IsYours() || (!isCloaking && Preferences::Has("Defensive escort cloaking"))) && DoCloak(*it, command))
-		{
-			// The ship chose to retreat from its target, e.g. to repair.
-			it->SetCommands(command);
-			continue;
-		}
+		bool escortShouldCloak = !isCloaking && Preferences::Has("Defensive escort cloaking");
+		if(!it->IsYours() || escortShouldCloak)
+			if(DoCloak(*it, command))
+			{
+				// The ship chose to retreat from its target, e.g. to repair.
+				it->SetCommands(command);
+				continue;
+			}
 
 		shared_ptr<Ship> parent = it->GetParent();
 		if(parent && parent->IsDestroyed())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2865,7 +2865,8 @@ bool AI::DoCloak(Ship &ship, Command &command)
 		// or 40% farther away before it begins decloaking again.
 		double hysteresis = ship.Commands().Has(Command::CLOAK) ? .4 : 0.;
 		// If cloaking costs nothing, and no one has asked you for help, cloak at will.
-		bool cloakFreely = (fuelCost <= 0.) && !ship.GetShipToAssist();
+		// Player ships should never cloak automatically if they are not in danger.
+		bool cloakFreely = (fuelCost <= 0.) && !ship.GetShipToAssist() && !ship.IsYours();
 		// If this ship is injured / repairing, it should cloak while under threat.
 		bool cloakToRepair = (ship.Health() < RETREAT_HEALTH + hysteresis)
 				&& (attributes.Get("shield generation") || attributes.Get("hull repair rate"));
@@ -2890,8 +2891,7 @@ bool AI::DoCloak(Ship &ship, Command &command)
 			}
 		}
 		// Choose to cloak if there are no enemies nearby and cloaking is sensible.
-		// Player ships should never cloak automatically if not damaged.
-		if(range == MAX_RANGE && cloakFreely && !ship.GetTargetShip() && !ship.IsYours())
+		if(range == MAX_RANGE && cloakFreely && !ship.GetTargetShip())
 			command |= Command::CLOAK;
 	}
 	return false;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -628,7 +628,7 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 				command |= Command::CLOAK;
 		}
 		// Cloak if the AI considers it appropriate.
-		else if(DoCloak(*it, command))
+		if((!it->IsYours() || (!isCloaking && Preferences::Has("Defensive escort cloaking"))) && DoCloak(*it, command))
 		{
 			// The ship chose to retreat from its target, e.g. to repair.
 			it->SetCommands(command);

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -147,6 +147,7 @@ void Preferences::Load()
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;
+	settings["Defensive escort cloaking"] = true;
 	settings["Extra fleet status messages"] = true;
 	settings["Target asteroid based on"] = true;
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -539,6 +539,7 @@ void PreferencesPanel::DrawSettings()
 		BOARDING_PRIORITY,
 		"Control ship with mouse",
 		EXPEND_AMMO,
+		"Defensive escort cloaking",
 		"Extra fleet status messages",
 		"Fighters transfer cargo",
 		"Rehire extra crew when lost",


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!)

----------------------
**Content (Artwork / Missions / Jobs)**

## Summary
{{summarize your content! Include links to related issues, in-game screenshots, etc.}}

## Save File
This save file can be used to play through the new mission content:
{{attach a save file that allows people to easily test your added mission content or see your new in-game art}}

## Artwork Checklist
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}


-----------------------
**Bugfix:** This PR addresses issue #{{insert number}}

## Fix Details
{{add details}}

## Testing Done
{{describe how you tested that the fix doesn't introduce other issues}}

## Save File
This save file can be used to verify the bugfix. The bug will occur when using {{insert commit hash / version}}, and will not occur when using this branch's build.
{{attach a save file that can be used to verify your bugfix. It MUST have no plugin requirements}}


-----------------------
**Feature:** This PR implements the feature request detailed and discussed in issue #{{insert number}}

## Feature Details
{{add details about the feature you implemented}}

## UI Screenshots
{{attach before + after screenshots of any changes to UI, or replace this line with "N/A"}}

## Usage Examples
{{if this feature is used in the data files, provide examples!}}

## Testing Done
{{describe how you tested the new feature}}

### Automated Tests Added
{{describe the automated tests you added (using the unit-test framework, integration-test framework or otherwise) to reduce the risk of regressions in the future. "N/A" if this PR is not for an in-game feature that needs to remain functional in the future. }}

## Performance Impact
{{describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed. }}
